### PR TITLE
Examine custom environment sources when syncing.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -370,7 +370,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 	}
 	if !reflect.DeepEqual(container1.EnvFrom, container2.EnvFrom) {
 		needsRollUpdate = true
-		reasons = append(reasons, "new statefulset's container environment sources doesn't match the current one")
+		reasons = append(reasons, "new statefulset's container environment sources don't match the current one")
 	}
 
 	if needsRollUpdate || needsReplace {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -368,6 +368,10 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 		needsRollUpdate = true
 		reasons = append(reasons, "new statefulset's container environment doesn't match the current one")
 	}
+	if !reflect.DeepEqual(container1.EnvFrom, container2.EnvFrom) {
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's container environment sources doesn't match the current one")
+	}
 
 	if needsRollUpdate || needsReplace {
 		match = false


### PR DESCRIPTION
When comparing statefulsets, make sure EnvFrom fields are compared
as well.